### PR TITLE
Update health_ins constraint

### DIFF
--- a/livelike/config.py
+++ b/livelike/config.py
@@ -372,6 +372,7 @@ need_year = [
     "civ_noninst_pop",
     "year_built",
     "internet",
+    "health_ins",
 ]
 
 # P-MEDM constraints

--- a/livelike/pums.py
+++ b/livelike/pums.py
@@ -460,7 +460,7 @@ def group_quarters_pop(gpp: pd.DataFrame, year: str) -> pd.Series:
     return gq
 
 
-def health_ins(gpp: pd.DataFrame) -> pd.DataFrame:
+def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     """Generates a person-level flag for health insurance
     coverage by age that harmonizes ACS PUMS questionnaire
     items AGEP and HINS1-7 with ACS SF table B27010.
@@ -601,26 +601,53 @@ def health_ins(gpp: pd.DataFrame) -> pd.DataFrame:
     )
     hins_employer_dpch.name = "employer_dpch"
 
+    # Two or more: Employer and Direct-purchase #
+    # hins_employer_dpch = 1 * ( # OG
+    #     hins.loc[:, employer_hins_cols + dpch_hins_cols].sum(axis=1) == 2
+    # )
+    employer_dpch_cols = employer_hins_cols + dpch_hins_cols
+    hins_employer_dpch = 1 * (
+        (hins.loc[:, employer_dpch_cols].sum(axis=1) == 2) &\
+        (hins.loc[:, ~hins.columns.isin(employer_dpch_cols)].sum(axis=1) == 0)
+    )
+    hins_employer_dpch.name = "employer_dpch"
+
     # Two or more: Employer and Medicare #
+    # hins_employer_medicare = 1 * ( # OG
+    #     hins.loc[:, employer_hins_cols + medicare_hins_cols].sum(axis=1) == 2
+    # )
+    employer_medicare_cols = employer_hins_cols + medicare_hins_cols
     hins_employer_medicare = 1 * (
-        hins.loc[:, employer_hins_cols + medicare_hins_cols].sum(axis=1) == 2
+        (hins.loc[:, employer_medicare_cols].sum(axis=1) == 2) &\
+        (hins.loc[:, ~hins.columns.isin(employer_medicare_cols)].sum(axis=1) == 0)
     )
     hins_employer_medicare.name = "employer_medicare"
 
     # Two ore more: Direct-purchase and Medicare #
+    # hins_dpch_medicare = 1 * ( # OG
+    #     hins.loc[:, dpch_hins_cols + medicare_hins_cols].sum(axis=1) == 2
+    # )
+    dpch_medicare_cols = dpch_hins_cols + medicare_hins_cols
     hins_dpch_medicare = 1 * (
-        hins.loc[:, dpch_hins_cols + medicare_hins_cols].sum(axis=1) == 2
+        (hins.loc[:, dpch_medicare_cols].sum(axis=1) == 2) &\
+        (hins.loc[:, ~hins.columns.isin(dpch_medicare_cols)].sum(axis=1) == 0)
     )
     hins_dpch_medicare.name = "dpch_medicare"
 
     # Two or more: Medicare and Medicaid/Means-Tested #
+    # hins_medicare_mcdmeans = 1 * (
+    #     hins.loc[:, medicare_hins_cols + mcdmeans_hins_cols].sum(axis=1) == 2
+    # )
+    medicare_mcdmeans_cols = medicare_hins_cols + mcdmeans_hins_cols
     hins_medicare_mcdmeans = 1 * (
-        hins.loc[:, medicare_hins_cols + mcdmeans_hins_cols].sum(axis=1) == 2
+        (hins.loc[:, medicare_mcdmeans_cols].sum(axis=1) == 2) &\
+        (hins.loc[:, ~hins.columns.isin(medicare_mcdmeans_cols)].sum(axis=1) == 0)
     )
     hins_medicare_mcdmeans.name = "medicare_mcdmeans"
 
     # No coverage #
-    hins_none = 1 * (gpp["HICOV"] == 2)
+    # hins_none = 1 * (gpp["HICOV"] == 2)
+    hins_none = 1 * (hins.sum(axis=1) == 0)
     hins_none.name = "none"
 
     ## Combine flags ##
@@ -655,6 +682,21 @@ def health_ins(gpp: pd.DataFrame) -> pd.DataFrame:
     ## Combine dfs ##
     hxa = intersect_dummies(hicov, agep)
     hxa.columns = [f"hicov_{col}" for col in hxa.columns]
+
+    # drop cols not in b27010
+    hxa = hxa.drop(
+        [
+            'hicov_aL19_dpch_medicare', 
+            'hicov_a19to34_dpch_medicare',
+            'hicov_aGE65_mcdmeans_only'
+        ],
+        axis=1
+    )
+
+    # limit to civilian noninst pop
+    # to match b27010 universe
+    cnp = civ_noninst_pop(gpp, year)
+    hxa = hxa * cnp.values[:,None]
 
     return hxa
 

--- a/livelike/pums.py
+++ b/livelike/pums.py
@@ -596,15 +596,6 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     hins_va_only = pd.Series(hins_va_only, name="va_only")
 
     # Two or more: Employer and Direct-purchase #
-    hins_employer_dpch = 1 * (
-        hins.loc[:, employer_hins_cols + dpch_hins_cols].sum(axis=1) == 2
-    )
-    hins_employer_dpch.name = "employer_dpch"
-
-    # Two or more: Employer and Direct-purchase #
-    # hins_employer_dpch = 1 * ( # OG
-    #     hins.loc[:, employer_hins_cols + dpch_hins_cols].sum(axis=1) == 2
-    # )
     employer_dpch_cols = employer_hins_cols + dpch_hins_cols
     hins_employer_dpch = 1 * (
         (hins.loc[:, employer_dpch_cols].sum(axis=1) == 2) &\
@@ -613,9 +604,6 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     hins_employer_dpch.name = "employer_dpch"
 
     # Two or more: Employer and Medicare #
-    # hins_employer_medicare = 1 * ( # OG
-    #     hins.loc[:, employer_hins_cols + medicare_hins_cols].sum(axis=1) == 2
-    # )
     employer_medicare_cols = employer_hins_cols + medicare_hins_cols
     hins_employer_medicare = 1 * (
         (hins.loc[:, employer_medicare_cols].sum(axis=1) == 2) &\
@@ -624,9 +612,6 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     hins_employer_medicare.name = "employer_medicare"
 
     # Two ore more: Direct-purchase and Medicare #
-    # hins_dpch_medicare = 1 * ( # OG
-    #     hins.loc[:, dpch_hins_cols + medicare_hins_cols].sum(axis=1) == 2
-    # )
     dpch_medicare_cols = dpch_hins_cols + medicare_hins_cols
     hins_dpch_medicare = 1 * (
         (hins.loc[:, dpch_medicare_cols].sum(axis=1) == 2) &\
@@ -635,9 +620,6 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     hins_dpch_medicare.name = "dpch_medicare"
 
     # Two or more: Medicare and Medicaid/Means-Tested #
-    # hins_medicare_mcdmeans = 1 * (
-    #     hins.loc[:, medicare_hins_cols + mcdmeans_hins_cols].sum(axis=1) == 2
-    # )
     medicare_mcdmeans_cols = medicare_hins_cols + mcdmeans_hins_cols
     hins_medicare_mcdmeans = 1 * (
         (hins.loc[:, medicare_mcdmeans_cols].sum(axis=1) == 2) &\

--- a/livelike/pums.py
+++ b/livelike/pums.py
@@ -668,7 +668,7 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     # drop cols not in b27010
     hxa = hxa.drop(
         [
-            'hicov_aL19_dpch_medicare', 
+            'hicov_aL19_dpch_medicare',
             'hicov_a19to34_dpch_medicare',
             'hicov_aGE65_mcdmeans_only'
         ],

--- a/livelike/pums.py
+++ b/livelike/pums.py
@@ -598,32 +598,32 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     # Two or more: Employer and Direct-purchase #
     employer_dpch_cols = employer_hins_cols + dpch_hins_cols
     hins_employer_dpch = 1 * (
-        (hins.loc[:, employer_dpch_cols].sum(axis=1) == 2) &\
-        (hins.loc[:, ~hins.columns.isin(employer_dpch_cols)].sum(axis=1) == 0)
+        (hins.loc[:, employer_dpch_cols].sum(axis=1) == 2)
+        & (hins.loc[:, ~hins.columns.isin(employer_dpch_cols)].sum(axis=1) == 0)
     )
     hins_employer_dpch.name = "employer_dpch"
 
     # Two or more: Employer and Medicare #
     employer_medicare_cols = employer_hins_cols + medicare_hins_cols
     hins_employer_medicare = 1 * (
-        (hins.loc[:, employer_medicare_cols].sum(axis=1) == 2) &\
-        (hins.loc[:, ~hins.columns.isin(employer_medicare_cols)].sum(axis=1) == 0)
+        (hins.loc[:, employer_medicare_cols].sum(axis=1) == 2)
+        & (hins.loc[:, ~hins.columns.isin(employer_medicare_cols)].sum(axis=1) == 0)
     )
     hins_employer_medicare.name = "employer_medicare"
 
     # Two ore more: Direct-purchase and Medicare #
     dpch_medicare_cols = dpch_hins_cols + medicare_hins_cols
     hins_dpch_medicare = 1 * (
-        (hins.loc[:, dpch_medicare_cols].sum(axis=1) == 2) &\
-        (hins.loc[:, ~hins.columns.isin(dpch_medicare_cols)].sum(axis=1) == 0)
+        (hins.loc[:, dpch_medicare_cols].sum(axis=1) == 2)
+        & (hins.loc[:, ~hins.columns.isin(dpch_medicare_cols)].sum(axis=1) == 0)
     )
     hins_dpch_medicare.name = "dpch_medicare"
 
     # Two or more: Medicare and Medicaid/Means-Tested #
     medicare_mcdmeans_cols = medicare_hins_cols + mcdmeans_hins_cols
     hins_medicare_mcdmeans = 1 * (
-        (hins.loc[:, medicare_mcdmeans_cols].sum(axis=1) == 2) &\
-        (hins.loc[:, ~hins.columns.isin(medicare_mcdmeans_cols)].sum(axis=1) == 0)
+        (hins.loc[:, medicare_mcdmeans_cols].sum(axis=1) == 2)
+        & (hins.loc[:, ~hins.columns.isin(medicare_mcdmeans_cols)].sum(axis=1) == 0)
     )
     hins_medicare_mcdmeans.name = "medicare_mcdmeans"
 
@@ -668,17 +668,17 @@ def health_ins(gpp: pd.DataFrame, year: str) -> pd.DataFrame:
     # drop cols not in b27010
     hxa = hxa.drop(
         [
-            'hicov_aL19_dpch_medicare',
-            'hicov_a19to34_dpch_medicare',
-            'hicov_aGE65_mcdmeans_only'
+            "hicov_aL19_dpch_medicare",
+            "hicov_a19to34_dpch_medicare",
+            "hicov_aGE65_mcdmeans_only",
         ],
-        axis=1
+        axis=1,
     )
 
     # limit to civilian noninst pop
     # to match b27010 universe
     cnp = civ_noninst_pop(gpp, year)
-    hxa = hxa * cnp.values[:,None]
+    hxa = hxa * cnp.values[:, None]
 
     return hxa
 

--- a/livelike/tests/test_pums.py
+++ b/livelike/tests/test_pums.py
@@ -183,7 +183,7 @@ def test_group_quarters_pop(column, year):
 def test_health_ins():
     gpp = pandas.DataFrame(
         {
-            "TYPE" : [2, 1, 1, 3],
+            "TYPE": [2, 1, 1, 3],
             "AGEP": [20, 30, 40, 50],
             "HICOV": [1, 1, 1, 1],
             "HINS1": [2, 2, 2, 1],

--- a/livelike/tests/test_pums.py
+++ b/livelike/tests/test_pums.py
@@ -183,24 +183,38 @@ def test_group_quarters_pop(column, year):
 def test_health_ins():
     gpp = pandas.DataFrame(
         {
+            "TYPE" : [2, 1, 1, 3],
             "AGEP": [20, 30, 40, 50],
-            "HICOV": [1, 2, 1, 2],
-            "HINS1": [1, 0, 0, 0],
-            "HINS2": [0, 0, 0, 0],
-            "HINS3": [0, 1, 0, 0],
-            "HINS4": [0, 0, 0, 0],
-            "HINS5": [0, 0, 1, 0],
-            "HINS6": [0, 0, 0, 0],
-            "HINS7": [0, 0, 0, 1],
+            "HICOV": [1, 1, 1, 1],
+            "HINS1": [2, 2, 2, 1],
+            "HINS2": [2, 2, 2, 2],
+            "HINS3": [2, 1, 2, 2],
+            "HINS4": [1, 2, 2, 2],
+            "HINS5": [2, 2, 2, 2],
+            "HINS6": [2, 2, 2, 2],
+            "HINS7": [2, 2, 1, 2],
         }
     )
 
     known = pandas.read_csv(
         io.StringIO(
-            "hicov_aL19_employer_only,hicov_aL19_dpch_only,hicov_aL19_medicare_only,hicov_aL19_mcdmeans_only,hicov_aL19_trimil_only,hicov_aL19_va_only,hicov_aL19_employer_dpch,hicov_aL19_employer_medicare,hicov_aL19_dpch_medicare,hicov_aL19_medicare_mcdmeans,hicov_aL19_none,hicov_a19to34_employer_only,hicov_a19to34_dpch_only,hicov_a19to34_medicare_only,hicov_a19to34_mcdmeans_only,hicov_a19to34_trimil_only,hicov_a19to34_va_only,hicov_a19to34_employer_dpch,hicov_a19to34_employer_medicare,hicov_a19to34_dpch_medicare,hicov_a19to34_medicare_mcdmeans,hicov_a19to34_none,hicov_a35to64_employer_only,hicov_a35to64_dpch_only,hicov_a35to64_medicare_only,hicov_a35to64_mcdmeans_only,hicov_a35to64_trimil_only,hicov_a35to64_va_only,hicov_a35to64_employer_dpch,hicov_a35to64_employer_medicare,hicov_a35to64_dpch_medicare,hicov_a35to64_medicare_mcdmeans,hicov_a35to64_none,hicov_aGE65_employer_only,hicov_aGE65_dpch_only,hicov_aGE65_medicare_only,hicov_aGE65_mcdmeans_only,hicov_aGE65_trimil_only,hicov_aGE65_va_only,hicov_aGE65_employer_dpch,hicov_aGE65_employer_medicare,hicov_aGE65_dpch_medicare,hicov_aGE65_medicare_mcdmeans,hicov_aGE65_none\n0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0\n"  # noqa: E501
+            "hicov_aL19_employer_only,hicov_aL19_dpch_only,hicov_aL19_medicare_only,hicov_aL19_mcdmeans_only,hicov_aL19_trimil_only,"
+            "hicov_aL19_va_only,hicov_aL19_employer_dpch,hicov_aL19_employer_medicare,hicov_aL19_medicare_mcdmeans,hicov_aL19_none,"
+            "hicov_a19to34_employer_only,hicov_a19to34_dpch_only,hicov_a19to34_medicare_only,hicov_a19to34_mcdmeans_only,"
+            "hicov_a19to34_trimil_only,hicov_a19to34_va_only,hicov_a19to34_employer_dpch,hicov_a19to34_employer_medicare,"
+            "hicov_a19to34_medicare_mcdmeans,hicov_a19to34_none,hicov_a35to64_employer_only,hicov_a35to64_dpch_only,"
+            "hicov_a35to64_medicare_only,hicov_a35to64_mcdmeans_only,hicov_a35to64_trimil_only,hicov_a35to64_va_only,"
+            "hicov_a35to64_employer_dpch,hicov_a35to64_employer_medicare,hicov_a35to64_dpch_medicare,hicov_a35to64_medicare_mcdmeans,"
+            "hicov_a35to64_none,hicov_aGE65_employer_only,hicov_aGE65_dpch_only,hicov_aGE65_medicare_only,hicov_aGE65_trimil_only,"
+            "hicov_aGE65_va_only,hicov_aGE65_employer_dpch,hicov_aGE65_employer_medicare,hicov_aGE65_dpch_medicare,"
+            "hicov_aGE65_medicare_mcdmeans,hicov_aGE65_none\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0\n"
+            "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
         )
     )
-    observed = livelike.pums.health_ins(gpp)
+    observed = livelike.pums.health_ins(gpp, 2019)
     pandas.testing.assert_frame_equal(observed, known)
 
 

--- a/utilities/prep_test_notebook_solutions.py
+++ b/utilities/prep_test_notebook_solutions.py
@@ -155,7 +155,11 @@ t1 = time.time()
 tract_supertract_2023_puma = "4701501"
 
 pup_tract_supertract_2023 = acs.puma(
-    tract_supertract_2023_puma, year=2023, target_zone="trt", keep_geo=True, censusapikey=key
+    tract_supertract_2023_puma,
+    year=2023,
+    target_zone="trt",
+    keep_geo=True,
+    censusapikey=key
 )
 
 pmd_tract_supertract_2023 = PMEDM(


### PR DESCRIPTION
Addresses #7.

Also revamped the unit test (`test_pums.test_health_ins()`) to:
- Use item levels matching PUMS (`1` -> `yes`, `2` -> `no`)
- Use all `HICOV == 1` since every record has a `HINS` type.
- Account for institutional vs. non-institutional group quarters (via `TYPE`). 