### PR TITLE
update certifi pin – `<=2025.1.31`

### DIFF
--- a/.ci/py311_livelike_latest.yaml
+++ b/.ci/py311_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.11
   - awkward
-  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
+  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py311_livelike_latest.yaml
+++ b/.ci/py311_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.11
   - awkward
-  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
+  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py311_livelike_latest.yaml
+++ b/.ci/py311_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.11
   - awkward
-  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
+  - ca-certificates<=2025.1.31 # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py311_livelike_latest.yaml
+++ b/.ci/py311_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.11
   - awkward
-  - ca-certificates!=2025.4.26 # see gh#97
+  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py311_livelike_min.yaml
+++ b/.ci/py311_livelike_min.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.11
   - awkward=2.6.2
-  - ca-certificates!=2025.4.26 # see gh#97
+  - ca-certificates==2025.1.31 # see gh#97
   - deprecation
   - dill
   - geopandas=1.0.1

--- a/.ci/py312_livelike_dev.yaml
+++ b/.ci/py312_livelike_dev.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
+  - ca-certificates # see gh#97,#102 -- EXPECTED TO FAIL compatible release of python-certifi
   - dill
   - cython
   - deprecation

--- a/.ci/py312_livelike_dev.yaml
+++ b/.ci/py312_livelike_dev.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
+  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
   - dill
   - cython
   - deprecation

--- a/.ci/py312_livelike_dev.yaml
+++ b/.ci/py312_livelike_dev.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - ca-certificates!=2025.4.26 # see gh#97
+  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
   - dill
   - cython
   - deprecation

--- a/.ci/py312_livelike_latest.yaml
+++ b/.ci/py312_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
+  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py312_livelike_latest.yaml
+++ b/.ci/py312_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - "ca-certificates<=2025.1.31,>2025.6.15" # see gh#97,#102
+  - ca-certificates<=2025.1.31 # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/.ci/py312_livelike_latest.yaml
+++ b/.ci/py312_livelike_latest.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.12
   - awkward
-  - ca-certificates!=2025.4.26 # see gh#97
+  - ca-certificates<=2025.1.31,>2025.6.15 # see gh#97,#102
   - deprecation
   - dill
   - geopandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "awkward>=2.6",
-    "certifi<=2025.1.31,>2025.6.15", # see gh#97, #102
+    "certifi<=2025.1.31", # see gh#97, #102
     "deprecation",
     "dill",
     "geopandas>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "awkward>=2.6",
-    "certifi!=2025.4.26", # see gh#97
+    "certifi<=2025.1.31,>2025.6.15", # see gh#97, #102
     "deprecation",
     "dill",
     "geopandas>=1.0",


### PR DESCRIPTION
* ca-certificates<=2025.1.31,>2025.6.15
* #102 

----------------------------

* this is a hassle, but we'll have to make do for now I suppose
* pinning
  * `pyproject.toml` to `<=2025.1.31`
  * CI min `==2025.1.31`
  * CI latest to `<=2025.1.31`
  * CI dev to `None` -- expected failure for `2025.6.15` 
  * we'll just have to deal with failing `dev` as a checker for compat when a new release to done by `cerifi`... yuck