### PR TITLE
test expected failure - `test_get_vre_tables()`

### DIFF
--- a/livelike/tests/test_acs_get_vre_tables.py
+++ b/livelike/tests/test_acs_get_vre_tables.py
@@ -11,7 +11,7 @@ def test_get_vre_tables():
     # a simple smoke test that ensures results are returned
 
     if pytest.DEV_CI:
-        # NOTE: When this specific block starts ot fail
+        # NOTE: When this specific block starts to fail
         # NOTE: that's the cue that certifi/ca-certificates
         # NOTE: is fixed and we can remove the pin.
         # NOTE: See gh#105


### PR DESCRIPTION
This PR:
* resolves #105 
* resolves #104
* xref https://github.com/likeness-pop/likeness-vitals/issues/37

When the test block starts to fail that's in this PR, it's the cue that `certifi`/`ca-certificates` *is fixed* and we can remove the pin.

